### PR TITLE
fix crash on nonexistent constant in iOS 7

### DIFF
--- a/Core/Source/DTKeychainItem.m
+++ b/Core/Source/DTKeychainItem.m
@@ -88,6 +88,10 @@
 	{
 		[self setValue:value forKey:@"descriptionText"];
 	}
+    else if ((&kSecAttrAccessControl != NULL) && [key isEqualToString:(__bridge __strong id)(kSecAttrAccessControl)])
+    {
+        // ignore
+    }
 	else if ([key isEqualToString:(__bridge __strong id)(kSecAttrGeneric)])
 	{
 		_genericAttribute = value;

--- a/Core/Source/DTKeychainItem.m
+++ b/Core/Source/DTKeychainItem.m
@@ -88,10 +88,6 @@
 	{
 		[self setValue:value forKey:@"descriptionText"];
 	}
-	else if ([key isEqualToString:(__bridge __strong id)(kSecAttrAccessControl)])
-	{
-		// ignore
-	}
 	else if ([key isEqualToString:(__bridge __strong id)(kSecAttrGeneric)])
 	{
 		_genericAttribute = value;


### PR DESCRIPTION
This was causing a crash in iOS7. Since it is being ignored I just removed it.